### PR TITLE
Add variable type completions

### DIFF
--- a/robotframework-ls/src/robotframework_ls/impl/variable_type_completions.py
+++ b/robotframework-ls/src/robotframework_ls/impl/variable_type_completions.py
@@ -1,0 +1,72 @@
+from typing import List, Set
+import ast
+
+from robocorp_ls_core.lsp import (
+    CompletionItem,
+    CompletionItemKind,
+    InsertTextFormat,
+    Position,
+    Range,
+    TextEdit,
+    CompletionItemTypedDict,
+)
+from robotframework_ls.impl.protocols import ICompletionContext
+
+
+_BUILTIN_TYPES = [str, int, float, bool, list, tuple, dict, set, bytes]
+
+
+def _gather_type_names(completion_context: ICompletionContext) -> List[str]:
+    names: Set[str] = {t.__name__ for t in _BUILTIN_TYPES}
+    ws = completion_context.workspace
+    if ws is not None:
+        for uri in ws.iter_all_doc_uris_in_workspace((".py",)):
+            doc = ws.get_document(uri, accept_from_file=True)
+            if not doc:
+                continue
+            try:
+                tree = ast.parse(doc.source)
+            except Exception:
+                continue
+            for node in tree.body:
+                if isinstance(node, ast.ClassDef):
+                    names.add(node.name)
+    return sorted(names)
+
+
+def _matches_context(prefix: str) -> bool:
+    import re
+
+    if re.search(r"\$\{[^}:]+:$", prefix):
+        return True
+    if re.search(r"\bVAR\s+[^:=]+:$", prefix):
+        return True
+    return False
+
+
+def complete(completion_context: ICompletionContext) -> List[CompletionItemTypedDict]:
+    line = completion_context.doc.get_line(completion_context.sel.line)
+    prefix = line[: completion_context.sel.col]
+    if not prefix.endswith(":"):
+        return []
+
+    if not _matches_context(prefix):
+        return []
+
+    type_names = _gather_type_names(completion_context)
+    ret: List[CompletionItemTypedDict] = []
+    for name in type_names:
+        ci = CompletionItem(
+            label=name,
+            kind=CompletionItemKind.Class,
+            text_edit=TextEdit(
+                Range(
+                    start=Position(completion_context.sel.line, completion_context.sel.col),
+                    end=Position(completion_context.sel.line, completion_context.sel.col),
+                ),
+                name,
+            ),
+            insertTextFormat=InsertTextFormat.PlainText,
+        )
+        ret.append(ci.to_dict())
+    return ret

--- a/robotframework-ls/src/robotframework_ls/server_api/server.py
+++ b/robotframework-ls/src/robotframework_ls/server_api/server.py
@@ -77,6 +77,7 @@ def complete_all(
     from robotframework_ls.impl import section_name_completions
     from robotframework_ls.impl import keyword_completions
     from robotframework_ls.impl import variable_completions
+    from robotframework_ls.impl import variable_type_completions
     from robotframework_ls.impl import dictionary_completions
     from robotframework_ls.impl import filesystem_section_completions
     from robotframework_ls.impl import keyword_parameter_completions
@@ -117,6 +118,9 @@ def complete_all(
                 )
                 ret.extend(library_names_completions.complete(completion_context))
                 return ret
+
+    if not ret:
+        ret.extend(variable_type_completions.complete(completion_context))
 
     if not ret:
         ret.extend(variable_completions.complete(completion_context))

--- a/robotframework-ls/tests/robotframework_ls_tests/completions/test_variable_type_completions.py
+++ b/robotframework-ls/tests/robotframework_ls_tests/completions/test_variable_type_completions.py
@@ -1,0 +1,25 @@
+import pytest
+
+from robotframework_ls.impl.completion_context import CompletionContext
+from robotframework_ls.server_api.server import complete_all
+
+
+def _get_completion_labels(completions):
+    return {c["label"] for c in completions}
+
+
+def test_type_completion_after_colon(workspace, libspec_manager):
+    workspace.set_root("case_vars_file", libspec_manager=libspec_manager)
+    doc, selected = workspace.put_doc_get_line_col(
+        "typed.robot",
+        "*** Test Cases ***\nTest\n    ${var:|}\n",
+    )
+    line, col = selected.get_end_line_col()
+    completions = complete_all(
+        CompletionContext(doc, workspace=workspace.ws, line=line, col=col)
+    )
+    labels = _get_completion_labels(completions)
+    assert "str" in labels
+    assert "MyVars" in labels
+
+


### PR DESCRIPTION
## Summary
- add provider for typed variable completions
- integrate into server completion pipeline
- test variable type completions

## Testing
- `pytest robotframework-ls/tests/robotframework_ls_tests/completions/test_variable_type_completions.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6844f3c7b110832eb205171c8f7e46a6