### PR TITLE
Update changelog

### DIFF
--- a/robotframework-ls/docs/changelog.md
+++ b/robotframework-ls/docs/changelog.md
@@ -3,9 +3,11 @@ New in 1.13.0 (2024-10-03)
 
 ### New features
 
-- The `Robot Framework Language Server` can now work both with `Robocorp Code` (which is currently deprecated) 
+- The `Robot Framework Language Server` can now work both with `Robocorp Code` (which is currently deprecated)
   as well as well as with the new `Sema4.ai VSCode extension` (which supersedes `Robocorp Code` for `Robots`
   development and also has support for developing AI actions).
+- Added support for defining variable scopes in `VAR` statements (e.g. `GLOBAL`, `SUITE`, `TEST`, `RESOURCE`),
+  with typed variable hints planned for a future release.
 
 
 New in 1.12.0 (2024-04-12)


### PR DESCRIPTION
## Summary
- add note about VAR statement scopes in upcoming release

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'robotframework_interactive')*

------
https://chatgpt.com/codex/tasks/task_e_6844f3ce95e4832eabd0453f29fb220c