### PR TITLE
Fix test runner path

### DIFF
--- a/robocorp-python-ls-core/tests/run_tests.py
+++ b/robocorp-python-ls-core/tests/run_tests.py
@@ -49,12 +49,15 @@ def main():
         initial_time = time.time()
         try:
             args = [sys.executable, "-m", "pytest"] + pytest_args
+            env = os.environ.copy()
+            src_dir = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "src")
+            env["PYTHONPATH"] = os.pathsep.join([src_dir, env.get("PYTHONPATH", "")])
             timeout = int(os.environ.get("RUN_TESTS_TIMEOUT", "100"))
             write(
                 "Calling:\n  cwd:%s\n  args: %s\n  timeout: %s"
                 % (os.path.abspath(os.getcwd()), args, timeout)
             )
-            process = subprocess.Popen(args)
+            process = subprocess.Popen(args, env=env)
             pid = process.pid
             while (time.time() - initial_time) < timeout:
                 time.sleep(1)


### PR DESCRIPTION
## Summary
- ensure the `robocorp_ls_core` tests run without needing manual PYTHONPATH

## Testing
- `python -u tests/run_tests.py -rfE -otests_output -vv .`

------
https://chatgpt.com/codex/tasks/task_e_6845a138eba4832e9395965c5a7ad280