### PR TITLE
Support custom regex in variable matching

### DIFF
--- a/robotframework-ls/src/robotframework_ls/impl/text_utilities.py
+++ b/robotframework-ls/src/robotframework_ls/impl/text_utilities.py
@@ -94,7 +94,6 @@ def matches_name_with_variables(name: str, name_with_variables: str) -> bool:
     """
 
     from robotframework_ls.impl import ast_utils
-    from robotframework_ls.impl.variable_resolve import extract_variable_base
 
     try:
         tokenized_vars = ast_utils.tokenize_variables_from_name(name_with_variables)
@@ -104,22 +103,19 @@ def matches_name_with_variables(name: str, name_with_variables: str) -> bool:
         regexp = []
         for t in tokenized_vars:
             if t.type == t.VARIABLE:
-                variable_base = extract_variable_base(t.value)
-                i = variable_base.find(":")
-                if i > 0:
-                    custom_regexp = variable_base[i + 1 :]
+                var_text = t.value[2:-1]
+                if ":" in var_text:
+                    _, custom_regexp = var_text.split(":", 1)
                     try:
                         pattern = _EmbeddedArgumentParser.format_custom_regexp(
-                            f"{custom_regexp}"
+                            custom_regexp
                         )
                     except Exception:
                         log.exception(
                             f"Error formatting regexp: {custom_regexp} when matching: {name_with_variables}."
                         )
                         return False
-
                     regexp.append(f"({pattern})")
-
                 else:
                     regexp.append("(.*?)")  # default pattern
             else:

--- a/robotframework-ls/tests/robotframework_ls_tests/completions/test_text_utilities.py
+++ b/robotframework-ls/tests/robotframework_ls_tests/completions/test_text_utilities.py
@@ -65,6 +65,22 @@ def test_matches_name_with_variables_with_custom_regexp():
     )
 
 
+def test_matches_name_with_variables_default_pattern():
+    from robotframework_ls.impl.text_utilities import matches_name_with_variables
+    from robotframework_ls.impl.text_utilities import normalize_robot_name
+
+    keyword_name_call_text = "Hello there"
+    keyword_name = "Hello ${who}"
+    assert matches_name_with_variables(
+        normalize_robot_name(keyword_name_call_text), normalize_robot_name(keyword_name)
+    )
+
+    keyword_name_call_text = "Hi there"
+    assert not matches_name_with_variables(
+        normalize_robot_name(keyword_name_call_text), normalize_robot_name(keyword_name)
+    )
+
+
 def test_iter_dotted_names():
     from robotframework_ls.impl.text_utilities import iter_dotted_names
 


### PR DESCRIPTION
## Summary
- handle custom regex in `matches_name_with_variables`
- test custom and default matching patterns

## Testing
- `PYTHONPATH=robotframework-ls/src:robocorp-python-ls-core/src python -m pytest robotframework-ls/tests/robotframework_ls_tests/completions/test_text_utilities.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6845ff05eb64832ea74ea740f95db56c