### PR TITLE
Update keyword execution for Robot 7

### DIFF
--- a/robotframework-ls/src/robotframework_debug_adapter/debugger_impl.py
+++ b/robotframework-ls/src/robotframework_debug_adapter/debugger_impl.py
@@ -614,13 +614,17 @@ Evaluation
 
             kw = Keyword(name, args=node.args, assign=assign)
             ctx = info.execution_context
-            try:
+
+            from robotframework_ls.impl.robot_version import get_robot_major_version
+
+            major = get_robot_major_version()
+            if major >= 7:
                 from robot.result import Keyword as KeywordResult  # type: ignore
-            except Exception:
-                return EvaluationResult(kw.run(ctx))
-            else:
+
                 result = KeywordResult()
                 return EvaluationResult(kw.run(result, ctx))
+            else:
+                return EvaluationResult(kw.run(ctx))
 
         raise UnableToEvaluateError("Unable to evaluate: %s" % (self.expression,))
 

--- a/robotframework-ls/tests/robotframework_debug_adapter_tests/test_debug_adapter.py
+++ b/robotframework-ls/tests/robotframework_debug_adapter_tests/test_debug_adapter.py
@@ -16,6 +16,9 @@ import os.path
 from robotframework_debug_adapter_tests.fixtures import _DebuggerAPI
 import json
 import pytest
+from robotframework_ls.impl.robot_version import get_robot_major_version
+
+IS_ROBOT_7_ONWARDS = get_robot_major_version() >= 7
 
 
 def test_invalid_launch_1(debugger_api: _DebuggerAPI):
@@ -751,7 +754,10 @@ def test_evaluate(debugger_api: _DebuggerAPI):
     response = debugger_api.evaluate(
         "My Equal Redefined     2   2", frameId=json_hit.frame_id, context="repl"
     )
-    assert response.body.result == "None"
+    if IS_ROBOT_7_ONWARDS:
+        assert response.body.result == "None"
+    else:
+        assert response.body.result == "None"
 
     assert json_hit.stack_trace_response.body.stackFrames[0]["id"] == json_hit.frame_id
 

--- a/robotframework-ls/tests/robotframework_debug_adapter_tests/test_debugger_core.py
+++ b/robotframework-ls/tests/robotframework_debug_adapter_tests/test_debugger_core.py
@@ -13,6 +13,7 @@ from robotframework_ls.impl.robot_version import get_robot_major_version
 # We don't even support version 2, so, this is ok.
 IS_ROBOT_4_ONWARDS = get_robot_major_version() >= 4
 IS_ROBOT_5_ONWARDS = get_robot_major_version() >= 5
+IS_ROBOT_7_ONWARDS = get_robot_major_version() >= 7
 
 
 class DummyBusyWait(object):


### PR DESCRIPTION
## Summary
- use `get_robot_major_version()` to decide how to call `Keyword.run`
- adapt debug adapter tests with new version constant
- add Robot 7 detection constant in debugger core tests

## Testing
- `pytest robotframework-ls/tests/robotframework_debug_adapter_tests/test_debug_adapter.py::test_evaluate -q` *(fails: TerminatedEvent mismatch)*
- `pytest robotframework-ls/tests/robotframework_debug_adapter_tests/test_evaluate_assign -q` *(fails: TerminatedEvent mismatch)*


------
https://chatgpt.com/codex/tasks/task_e_6845ff01db0c832e93dff19a7ed7c89b