### PR TITLE
Improve variable type completions

### DIFF
--- a/robotframework-ls/src/robotframework_ls/impl/robot_version.py
+++ b/robotframework-ls/src/robotframework_ls/impl/robot_version.py
@@ -75,3 +75,8 @@ def get_robot_major_minor_version() -> Tuple[int, int]:
 
 def robot_version_supports_language():
     return get_robot_major_minor_version() >= (5, 1)
+
+
+def robot_version_supports_variable_types() -> bool:
+    """Return True if the Robot Framework version supports typed variables."""
+    return get_robot_major_minor_version() >= (7, 3)

--- a/robotframework-ls/src/robotframework_ls/impl/variable_type_completions.py
+++ b/robotframework-ls/src/robotframework_ls/impl/variable_type_completions.py
@@ -10,11 +10,24 @@ from robocorp_ls_core.lsp import (
     CompletionItemTypedDict,
 )
 from robotframework_ls.impl.protocols import ICompletionContext
+from robotframework_ls.impl.robot_version import robot_version_supports_variable_types
 
 
 import datetime
 
-_BUILTIN_TYPES = [str, int, float, bool, list, tuple, dict, set, bytes, datetime.date]
+_BUILTIN_TYPES = [
+    str,
+    int,
+    float,
+    bool,
+    list,
+    tuple,
+    dict,
+    set,
+    bytes,
+    datetime.date,
+    datetime.datetime,
+]
 
 
 def _gather_type_names(completion_context: ICompletionContext) -> List[str]:
@@ -33,6 +46,8 @@ def _matches_context(prefix: str) -> bool:
 
 
 def complete(completion_context: ICompletionContext) -> List[CompletionItemTypedDict]:
+    if not robot_version_supports_variable_types():
+        return []
     line = completion_context.doc.get_line(completion_context.sel.line)
     prefix = line[: completion_context.sel.col]
     if ":" not in prefix:

--- a/robotframework-ls/tests/robotframework_ls_tests/completions/test_variable_type_completions.py
+++ b/robotframework-ls/tests/robotframework_ls_tests/completions/test_variable_type_completions.py
@@ -20,6 +20,24 @@ def test_type_completion_after_colon(workspace, libspec_manager):
     )
     labels = _get_completion_labels(completions)
     assert "str" in labels
+    assert "datetime" in labels
     assert "MyVars" not in labels
+
+
+def test_type_completion_disabled_for_old_version(workspace, libspec_manager, monkeypatch):
+    from robotframework_ls.impl import robot_version
+
+    monkeypatch.setattr(robot_version, "get_robot_major_minor_version", lambda: (7, 2))
+
+    workspace.set_root("case_vars_file", libspec_manager=libspec_manager)
+    doc, selected = workspace.put_doc_get_line_col(
+        "typed.robot",
+        "*** Test Cases ***\nTest\n    ${var: |}\n",
+    )
+    line, col = selected.get_end_line_col()
+    completions = complete_all(
+        CompletionContext(doc, workspace=workspace.ws, line=line, col=col)
+    )
+    assert completions == []
 
 


### PR DESCRIPTION
## Summary
- support variable type completions only when Robot Framework >=7.3
- include `datetime` type in completions
- add tests for new completions and for disabling when Robot <7.3
- drop changelog entry

## Testing
- `pytest robotframework-ls/tests/robotframework_ls_tests/completions/test_variable_type_completions.py -q`

------
https://chatgpt.com/codex/tasks/task_e_684605fb3d30832eb166d766387e6a0b