### PR TITLE
Fix debug console freeze when evaluating

### DIFF
--- a/robotframework-ls/src/robotframework_debug_adapter/debugger_impl.py
+++ b/robotframework-ls/src/robotframework_debug_adapter/debugger_impl.py
@@ -711,6 +711,10 @@ class _RobotDebuggerImpl(object):
         return self._reason
 
     @property
+    def is_paused(self) -> bool:
+        return self._run_state == STATE_PAUSED
+
+    @property
     def exc_name(self) -> Optional[str]:
         return self._exc_name
 

--- a/robotframework-ls/src/robotframework_debug_adapter/protocols.py
+++ b/robotframework-ls/src/robotframework_debug_adapter/protocols.py
@@ -48,6 +48,10 @@ class IBusyWait(Protocol):
 class IRobotDebugger(Protocol):
     busy_wait: IBusyWait
 
+    def is_paused(self) -> bool:
+        """Returns True if the debugger is currently paused."""
+        pass
+
     def reset(self):
         pass
 

--- a/robotframework-ls/src/robotframework_debug_adapter/run_robot__main__.py
+++ b/robotframework-ls/src/robotframework_debug_adapter/run_robot__main__.py
@@ -542,14 +542,22 @@ class _RobotTargetComm(threading.Thread):
         expression = arguments.expression
         context = arguments.context
         if self._debugger_impl and self._run_in_debug_mode:
-            eval_info = self._debugger_impl.evaluate(frame_id, expression, context)
-            try:
-                result = eval_info.future.result()
-            except Exception as e:
-                err = "".join(traceback.format_exception_only(type(e), e))
-                response = self._evaluate_response(request, err, error_message=err)
+            if not self._debugger_impl.is_paused:
+                get_log().info("Unable to evaluate (debugger not paused).")
+                response = self._evaluate_response(
+                    request,
+                    "",
+                    error_message="Unable to evaluate: debugger not paused.",
+                )
             else:
-                response = self._evaluate_response(request, str(result))
+                eval_info = self._debugger_impl.evaluate(frame_id, expression, context)
+                try:
+                    result = eval_info.future.result()
+                except Exception as e:
+                    err = "".join(traceback.format_exception_only(type(e), e))
+                    response = self._evaluate_response(request, err, error_message=err)
+                else:
+                    response = self._evaluate_response(request, str(result))
         else:
             get_log().info("Unable to evaluate (no debug mode).")
             response = self._evaluate_response(request, "")


### PR DESCRIPTION
## Summary
- check if debugger is paused before evaluating expressions
- expose `is_paused` on debugger interface
- implement `is_paused` in debugger implementation

## Testing
- `pytest robotframework-ls/tests/robotframework_debug_adapter_tests/test_debug_adapter.py::test_evaluate -q` *(fails: Vendored pydevd missing)*

------
https://chatgpt.com/codex/tasks/task_e_68471bd5d678832eb61cdd53e47fdefa