### PR TITLE
Clear robot target comm after run

### DIFF
--- a/robotframework-ls/src/robotframework_debug_adapter/run_robot__main__.py
+++ b/robotframework-ls/src/robotframework_debug_adapter/run_robot__main__.py
@@ -661,6 +661,7 @@ def main():
         exitcode = run_cli(robot_args, exit=False)
     finally:
         processor.terminate()
+        global_vars.set_global_robot_target_comm(None)
         if processor.terminated.wait(2):
             log.debug("Processed dap terminate event in robot.")
         close_logging_streams()


### PR DESCRIPTION
## Summary
- clean the global robot target communication reference after run

## Testing
- `PYTHONPATH=robotframework-ls/src python -m pytest robotframework-ls/tests/robotframework_debug_adapter_tests/test_debug_adapter_threaded.py -q` *(fails: `_queue.Empty`)*

------
https://chatgpt.com/codex/tasks/task_e_6862caa682f8832e8608fb625a14d5f1