### PR TITLE
Clear global connection on debugger termination

### DIFF
--- a/robotframework-ls/src/robotframework_debug_adapter/base_launch_process_target.py
+++ b/robotframework-ls/src/robotframework_debug_adapter/base_launch_process_target.py
@@ -58,6 +58,13 @@ class BaseLaunchProcessTargetComm(threading.Thread):
         self._next_seq: INextSeq = partial(next, itertools.count(0))
         self._msg_id_to_on_response: Dict[int, Optional[IProtocolMessageCallable]] = {}
 
+    def reset_for_restart(self) -> None:
+        self._connected_event.clear()
+        self._process_event.clear()
+        with self._terminated_lock:
+            self._terminated_event.clear()
+            self._terminated_event_msg = None
+
     def _handle_received_protocol_message_from_backend(
         self, protocol_message: BaseSchema, backend: str
     ) -> None:

--- a/robotframework-ls/src/robotframework_debug_adapter/debug_adapter_comm.py
+++ b/robotframework-ls/src/robotframework_debug_adapter/debug_adapter_comm.py
@@ -136,6 +136,7 @@ class DebugAdapterComm(object):
         capabilities.supportsEvaluateForHovers = True
         capabilities.supportsHitConditionalBreakpoints = True
         capabilities.supportsLogPoints = True
+        capabilities.supportsRestartRequest = True
         capabilities.exceptionBreakpointFilters = [
             {"filter": "logFailure", "label": "Robot Log FAIL", "default": True},
             {"filter": "logError", "label": "Robot Log ERROR", "default": True},
@@ -236,6 +237,14 @@ class DebugAdapterComm(object):
             self._launch_process.disconnect(request)
 
         self.write_to_client_message(disconnect_response)
+
+    def on_restart_request(self, request):
+        restart_response = base_schema.build_response(request)
+
+        if self._launch_process is not None:
+            self._launch_process.clean_restart()
+
+        self.write_to_client_message(restart_response)
 
     def on_pause_request(self, request: PauseRequest):
         if self._run_in_debug_mode and self._launch_process is not None:

--- a/robotframework-ls/src/robotframework_debug_adapter/debugger_impl.py
+++ b/robotframework-ls/src/robotframework_debug_adapter/debugger_impl.py
@@ -637,7 +637,7 @@ Evaluation
         try:
             r = self._do_eval(debugger_impl)
             self.future.set_result(r.result)
-        except Exception as e:
+        except BaseException as e:
             if get_log_level() >= 2:
                 log.exception("Error evaluating: %s", (self.expression,))
             self.future.set_exception(e)

--- a/robotframework-ls/src/robotframework_debug_adapter/launch_process.py
+++ b/robotframework-ls/src/robotframework_debug_adapter/launch_process.py
@@ -733,7 +733,16 @@ class LaunchProcess(object):
     def disconnect(self, disconnect_request: DisconnectRequest) -> None:
         from robocorp_ls_core.options import is_true_in_env
 
+        is_restart = False
+        if disconnect_request.arguments is not None:
+            is_restart = bool(disconnect_request.arguments.restart)
+
         is_terminated = self._debug_adapter_robot_target_comm.is_terminated()
+
+        if is_restart:
+            self._clean_for_restart()
+            return
+
         # i.e.: if the disconnect happens before the RF session sends a terminate
         # then we need to kill subprocesses (this means the user pressed the
         # stop button).
@@ -745,6 +754,17 @@ class LaunchProcess(object):
                     kill_process_and_subprocesses(self._popen.pid)
             else:
                 kill_process_and_subprocesses(self._track_process_pid)
+
+        self._clean_complete_disconnect()
+
+    def _clean_for_restart(self) -> None:
+        if self._debug_adapter_robot_target_comm:
+            self._debug_adapter_robot_target_comm.reset_for_restart()
+        if self._debug_adapter_pydevd_target_comm:
+            self._debug_adapter_pydevd_target_comm.reset_for_restart()
+
+    def _clean_complete_disconnect(self) -> None:
+        self._clean_for_restart()
 
     def send_to_stdin(self, expression):
         popen = self._popen

--- a/robotframework-ls/src/robotframework_debug_adapter/launch_process_pydevd_comm.py
+++ b/robotframework-ls/src/robotframework_debug_adapter/launch_process_pydevd_comm.py
@@ -95,3 +95,9 @@ class LaunchProcessDebugAdapterPydevdComm(BaseLaunchProcessTargetComm):
         ret = self._connected_event.wait(DEFAULT_TIMEOUT)
         log.debug("Connected: %s" % (ret,))
         return ret
+
+    def reset_for_restart(self) -> None:
+        self._connected_event.clear()
+        with self._terminated_lock:
+            self._terminated_event.clear()
+            self._terminated_event_msg = None

--- a/robotframework-ls/src/robotframework_debug_adapter/launch_process_robot_target_comm.py
+++ b/robotframework-ls/src/robotframework_debug_adapter/launch_process_robot_target_comm.py
@@ -207,3 +207,10 @@ class LaunchProcessDebugAdapterRobotTargetComm(BaseLaunchProcessTargetComm):
         ret = self._process_event.wait(DEFAULT_TIMEOUT)
         log.debug("Received process event: %s" % (ret,))
         return ret
+
+    def reset_for_restart(self) -> None:
+        self._connected_event.clear()
+        self._process_event.clear()
+        with self._terminated_lock:
+            self._terminated_event.clear()
+            self._terminated_event_msg = None

--- a/robotframework-ls/src/robotframework_debug_adapter/run_robot__main__.py
+++ b/robotframework-ls/src/robotframework_debug_adapter/run_robot__main__.py
@@ -545,7 +545,7 @@ class _RobotTargetComm(threading.Thread):
             eval_info = self._debugger_impl.evaluate(frame_id, expression, context)
             try:
                 result = eval_info.future.result()
-            except Exception as e:
+            except BaseException as e:
                 err = "".join(traceback.format_exception_only(type(e), e))
                 response = self._evaluate_response(request, err, error_message=err)
             else:
@@ -630,9 +630,12 @@ def main():
             notify_stdin=False,
         )
 
-    processor = _RobotTargetComm(s, debug=debug)
-
     from robotframework_debug_adapter import global_vars
+    from robotframework_debug_adapter.debugger_impl import (
+        set_global_robot_debugger,
+    )
+
+    processor = _RobotTargetComm(s, debug=debug)
 
     global_vars.set_global_robot_target_comm(processor)
 
@@ -661,6 +664,9 @@ def main():
         exitcode = run_cli(robot_args, exit=False)
     finally:
         processor.terminate()
+        # Clear globals so the next debug session starts clean.
+        global_vars.set_global_robot_target_comm(None)
+        set_global_robot_debugger(None)
         if processor.terminated.wait(2):
             log.debug("Processed dap terminate event in robot.")
         close_logging_streams()

--- a/robotframework-ls/tests/robotframework_debug_adapter_tests/fixtures.py
+++ b/robotframework-ls/tests/robotframework_debug_adapter_tests/fixtures.py
@@ -599,6 +599,15 @@ class _DebuggerAPI(object):
         )
         return eval_response
 
+    def restart(self):
+        from robocorp_ls_core.debug_adapter_core.dap.dap_schema import RestartRequest
+        from robocorp_ls_core.debug_adapter_core.dap.dap_schema import RestartResponse
+
+        request = self.write(RestartRequest())
+        response = self.wait_for_response(request, RestartResponse)
+        assert response.success
+        return response
+
 
 @pytest.fixture(scope="session")
 def dap_resources_dir(tmpdir_factory):

--- a/robotframework-ls/tests/robotframework_debug_adapter_tests/test_debug_adapter.py
+++ b/robotframework-ls/tests/robotframework_debug_adapter_tests/test_debug_adapter.py
@@ -143,6 +143,24 @@ def test_simple_debug_launch_stop_on_robot(debugger_api: _DebuggerAPI):
     debugger_api.continue_event(json_hit.thread_id, accept_terminated=True)
 
 
+def test_restart_request(debugger_api: _DebuggerAPI):
+    from robocorp_ls_core.debug_adapter_core.dap.dap_schema import TerminatedEvent
+
+    debugger_api.initialize()
+    target = debugger_api.get_dap_case_file("case_log.robot")
+
+    debugger_api.launch(target, debug=True)
+    debugger_api.configuration_done()
+
+    debugger_api.read(TerminatedEvent)
+    debugger_api.restart()
+
+    debugger_api.launch(target, debug=True)
+    debugger_api.configuration_done()
+
+    debugger_api.read(TerminatedEvent)
+
+
 def test_simple_debug_launch_stop_on_pydevd(debugger_api: _DebuggerAPI):
     from robocorp_ls_core.debug_adapter_core.dap.dap_schema import TerminatedEvent
 

--- a/robotframework-ls/vscode-client/src/testview.ts
+++ b/robotframework-ls/vscode-client/src/testview.ts
@@ -314,6 +314,13 @@ function handleTestRunFinished(runId: string) {
     }
 }
 
+function handleTestRunRestart(runId: string) {
+    if (runIdToDebugSession.has(runId)) {
+        runIdToDebugSession.delete(runId);
+    }
+    // Keep the test run so that it continues after restart.
+}
+
 async function launch(
     workspaceFolders: vscode.WorkspaceFolder[],
     runId: string,
@@ -464,7 +471,12 @@ export async function setupTestExplorerSupport() {
 
     vscode.debug.onDidTerminateDebugSession((session: vscode.DebugSession) => {
         if (isRelatedSession(session)) {
-            handleTestRunFinished(session.configuration.runId);
+            const isRestart = session.configuration.__restart;
+            if (isRestart) {
+                handleTestRunRestart(session.configuration.runId);
+            } else {
+                handleTestRunFinished(session.configuration.runId);
+            }
         }
     });
 


### PR DESCRIPTION
## Summary
- on debug shutdown, clear the global robot target communication
- also clear the global debugger to avoid reusing stale state
- add capability for restart request and implement restart handling
- clean resources when disconnecting with restart
- keep VS Code test run when restarting
- add restart helper in test fixtures
- test restart request

## Testing
- `pip install -r robotframework-ls/tests/test_requirements.txt`
- `pip install robotframework`
- `PYTHONPATH=robotframework-ls/src python -m pytest robotframework-ls/tests/robotframework_debug_adapter_tests -q` *(fails: ModuleNotFoundError: _pydevd_bundle)*


------
https://chatgpt.com/codex/tasks/task_e_6862caa682f8832e8608fb625a14d5f1