### PR TITLE
Add Robot Framework 7.4 secret type completions

### DIFF
--- a/robotframework-ls/README.md
+++ b/robotframework-ls/README.md
@@ -42,10 +42,11 @@ See: [Contributing](docs/contributing.md) for how to help in the development of 
 
 See: [Reporting Issue](docs/reporting_issues.md) for details on how to report some issue in the `Robot Framework Language Server`.
 
-## Features (1.14.0)
+## Features (1.15.0)
 
 -   Automatic client detection between Robocorp Code and Sema4.ai VSCode extensions.
 -   Configurable dictionary key completions (`robot.completions.dictionaryEntries.enable`).
+-   Robot Framework 7.4 typed variable completions, including the `Secret` type when available.
 -   Robot Output View:
     -   View current task/test being executed.
     -   Shows Keyword being executed in real time.

--- a/robotframework-ls/docs/changelog.md
+++ b/robotframework-ls/docs/changelog.md
@@ -5,6 +5,7 @@ New in 1.14.0 (2025-02-14)
 
 - Language server clients are now auto-detected, seamlessly switching between the legacy Robocorp Code extension and the newer Sema4.ai extension.
 - Added a configuration toggle (`robot.completions.dictionaryEntries.enable`) to decide when dictionary key completions should be suggested.
+- Completion suggestions now recognize Robot Framework 7.4 typed variables, including the new `Secret` type and other builtin converters.
 
 ### Bugfixes
 

--- a/robotframework-ls/docs/changelog.md
+++ b/robotframework-ls/docs/changelog.md
@@ -1,3 +1,16 @@
+New in 1.15.0 (2025-12-17)
+-----------------------------
+
+### New features
+
+- Completion suggestions now recognize Robot Framework 7.4 typed variables, including the new `Secret` type and other builtin converters.
+- Language server features that rely on Robot Framework 7.4 are gated to only activate when the detected runtime supports them.
+
+### Bugfixes
+
+- Guarded 7.4-specific completions to avoid offering unsupported types on earlier Robot Framework versions.
+
+
 New in 1.14.0 (2025-02-14)
 -----------------------------
 
@@ -5,7 +18,6 @@ New in 1.14.0 (2025-02-14)
 
 - Language server clients are now auto-detected, seamlessly switching between the legacy Robocorp Code extension and the newer Sema4.ai extension.
 - Added a configuration toggle (`robot.completions.dictionaryEntries.enable`) to decide when dictionary key completions should be suggested.
-- Completion suggestions now recognize Robot Framework 7.4 typed variables, including the new `Secret` type and other builtin converters.
 
 ### Bugfixes
 

--- a/robotframework-ls/docs/release.md
+++ b/robotframework-ls/docs/release.md
@@ -6,7 +6,7 @@ Steps to do a new release
 
 - Create release branch (`git branch -D release-robotframework-lsp&git checkout -b release-robotframework-lsp`)
 
-- Update version (`python -m dev set-version 1.14.0`).
+- Update version (`python -m dev set-version 1.15.0`).
 
 - Update README.md to add notes on features/fixes (on `robotframework-ls` and `robotframework-intellij`).
 
@@ -16,27 +16,27 @@ Steps to do a new release
   - Use `https://markdowntohtml.com/` to convert the changelog to HTML.
 
 - Push contents, get the build in https://github.com/robocorp/robotframework-lsp/actions and install locally to test.
-  - `mu acp Robot Framework Language Server Release 1.14.0`
+  - `mu acp Robot Framework Language Server Release 1.15.0`
 
 - Rebase with master (`git checkout master&git rebase release-robotframework-lsp`).
 
-- Create a tag (`git tag robotframework-lsp-1.14.0`) and push it.
+- Create a tag (`git tag robotframework-lsp-1.15.0`) and push it.
 
 - Send release msg. i.e.:
 
 Hi @channel,
 
-I'm happy to announce the release of `Robot Framework Language Server 1.14.0`.
+I'm happy to announce the release of `Robot Framework Language Server 1.15.0`.
 
 ### New features
 
-- The language server now detects whether the Robocorp Code or Sema4.ai client is active and adjusts its integration automatically.
-- New configuration toggle (`robot.completions.dictionaryEntries.enable`) allows choosing when dictionary key completions should appear.
+- Completion suggestions now recognize Robot Framework 7.4 typed variables, including the new `Secret` type and other builtin converters.
+- Language server features that rely on Robot Framework 7.4 are gated to only activate when the detected runtime supports them.
 
 
 ### Bugfixes
 
-- Improved resiliency when dictionary completions are disabled in workspaces that build keywords dynamically.
+- Guarded 7.4-specific completions to avoid offering unsupported types on earlier Robot Framework versions.
 
 ### Intellij
 

--- a/robotframework-ls/package.json
+++ b/robotframework-ls/package.json
@@ -3,7 +3,7 @@
     "displayName": "Robot Framework Language Server",
     "description": "VSCode extension support for Robot Framework",
     "author": "Fabio Zadrozny",
-    "homepage": "https://github.com/robocorp/robotframework-lsp/blob/robotframework-lsp-1.14.0/robotframework-ls/README.md",
+    "homepage": "https://github.com/robocorp/robotframework-lsp/blob/robotframework-lsp-1.15.0/robotframework-ls/README.md",
     "repository": {
         "type": "git",
         "url": "https://github.com/robocorp/robotframework-lsp.git"
@@ -12,7 +12,7 @@
         "url": "https://github.com/robocorp/robotframework-lsp/issues"
     },
     "license": "Apache 2.0",
-    "version": "1.14.0",
+    "version": "1.15.0",
     "icon": "images/icon.png",
     "publisher": "robocorp",
     "categories": [

--- a/robotframework-ls/src/robotframework_ls/__init__.py
+++ b/robotframework-ls/src/robotframework_ls/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "1.14.0"
+__version__ = "1.15.0"
 version_info = [int(x) for x in __version__.split(".")]
 
 import os.path

--- a/robotframework-ls/src/robotframework_ls/impl/robot_version.py
+++ b/robotframework-ls/src/robotframework_ls/impl/robot_version.py
@@ -80,3 +80,10 @@ def robot_version_supports_language():
 def robot_version_supports_variable_types() -> bool:
     """Return True if the Robot Framework version supports typed variables."""
     return get_robot_major_minor_version() >= (7, 3)
+
+
+def robot_version_supports_secret_variables() -> bool:
+    """Return True if the Robot Framework version supports secret variables."""
+
+    # Secret variables were added in Robot Framework 7.4.
+    return get_robot_major_minor_version() >= (7, 4)

--- a/robotframework-ls/src/robotframework_ls/impl/variable_type_completions.py
+++ b/robotframework-ls/src/robotframework_ls/impl/variable_type_completions.py
@@ -10,7 +10,10 @@ from robocorp_ls_core.lsp import (
     CompletionItemTypedDict,
 )
 from robotframework_ls.impl.protocols import ICompletionContext
-from robotframework_ls.impl.robot_version import robot_version_supports_variable_types
+from robotframework_ls.impl.robot_version import (
+    robot_version_supports_secret_variables,
+    robot_version_supports_variable_types,
+)
 
 
 import datetime
@@ -25,6 +28,8 @@ _BUILTIN_TYPES = [
     dict,
     set,
     bytes,
+    bytearray,
+    object,
     datetime.date,
     datetime.datetime,
 ]
@@ -32,7 +37,18 @@ _BUILTIN_TYPES = [
 
 def _gather_type_names(completion_context: ICompletionContext) -> List[str]:
     """Return only builtin type names."""
-    return sorted({t.__name__ for t in _BUILTIN_TYPES})
+    type_names = {t.__name__ for t in _BUILTIN_TYPES}
+
+    if robot_version_supports_secret_variables():
+        try:
+            from robot.api.types import Secret
+        except Exception:
+            # If Robot Framework is not available or is older than 7.4, just skip it.
+            pass
+        else:
+            type_names.add(Secret.__name__)
+
+    return sorted(type_names)
 
 
 def _matches_context(prefix: str) -> bool:

--- a/robotframework-ls/src/setup.py
+++ b/robotframework-ls/src/setup.py
@@ -105,7 +105,7 @@ def collect_other_vendored_files():
 
 setup(
     name="robotframework-lsp",
-    version="1.14.0",
+    version="1.15.0",
     description="Language Server Protocol implementation for Robot Framework",
     long_description=_readme.read_text(),
     url="https://github.com/robocorp/robotframework-lsp",

--- a/robotframework-ls/tests/robotframework_ls_tests/completions/test_variable_type_completions.py
+++ b/robotframework-ls/tests/robotframework_ls_tests/completions/test_variable_type_completions.py
@@ -47,3 +47,51 @@ def test_type_completion_disabled_for_old_version(
         CompletionContext(doc, workspace=workspace.ws, line=line, col=col)
     )
     assert completions == []
+
+
+@pytest.mark.skipif(
+    not robot_version_supports_variable_types(),
+    reason="Test requires RF typed variable support.",
+)
+def test_secret_type_completion_for_newer_versions(
+    workspace, libspec_manager, monkeypatch
+):
+    from robotframework_ls.impl import robot_version
+
+    monkeypatch.setattr(robot_version, "get_robot_major_minor_version", lambda: (7, 4))
+
+    workspace.set_root("case_vars_file", libspec_manager=libspec_manager)
+    doc, selected = workspace.put_doc_get_line_col(
+        "typed.robot",
+        "*** Test Cases ***\nTest\n    ${token: Secret|}\n",
+    )
+    line, col = selected.get_end_line_col()
+    completions = complete_all(
+        CompletionContext(doc, workspace=workspace.ws, line=line, col=col)
+    )
+    labels = _get_completion_labels(completions)
+    assert "Secret" in labels
+
+
+@pytest.mark.skipif(
+    not robot_version_supports_variable_types(),
+    reason="Test requires RF typed variable support.",
+)
+def test_secret_type_not_available_for_older_versions(
+    workspace, libspec_manager, monkeypatch
+):
+    from robotframework_ls.impl import robot_version
+
+    monkeypatch.setattr(robot_version, "get_robot_major_minor_version", lambda: (7, 3))
+
+    workspace.set_root("case_vars_file", libspec_manager=libspec_manager)
+    doc, selected = workspace.put_doc_get_line_col(
+        "typed.robot",
+        "*** Test Cases ***\nTest\n    ${token: Sec|}\n",
+    )
+    line, col = selected.get_end_line_col()
+    completions = complete_all(
+        CompletionContext(doc, workspace=workspace.ws, line=line, col=col)
+    )
+    labels = _get_completion_labels(completions)
+    assert "Secret" not in labels


### PR DESCRIPTION
## Summary
- add Robot Framework 7.4 feature gating for secret variables
- extend typed variable completions with new built-in types and Secret when supported
- cover secret completion behavior in tests and document the new support

## Testing
- PYTHONPATH=robotframework-ls/src:robocorp-python-ls-core/src python -m pytest robotframework-ls/tests/robotframework_ls_tests/completions/test_variable_type_completions.py -k secret -q *(fails: missing `pytest_timeout` dependency in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6940879eb750832eb78fe1e2583dd8bf)